### PR TITLE
Refactor/compatible with flink 1.0.3

### DIFF
--- a/data_enrichment/data_enrichment.py
+++ b/data_enrichment/data_enrichment.py
@@ -2,7 +2,7 @@ import os
 import json
 import sys
 from flink.plan.Environment import get_environment
-from flink.plan.Constants import INT, STRING, WriteMode
+from flink.plan.Constants import STRING, WriteMode
 from flink.functions.GroupReduceFunction import GroupReduceFunction
 
 __author__ = 'willmcginnis'
@@ -37,9 +37,9 @@ if __name__ == "__main__":
     dimensional_data = env.read_csv(dim_file, types=[STRING, STRING])
 
     input_data \
-        .map(lambda x: json_to_tuple(json.loads(x), ['car', 'attr']), (STRING, STRING)) \
+        .map(lambda x: json_to_tuple(json.loads(x), ['car', 'attr'])) \
         .join(dimensional_data).where(1).equal_to(0) \
-        .map(lambda x: 'This %s is %s' % (x[0][0], x[1][1]), STRING) \
+        .map(lambda x: 'This %s is %s' % (x[0][0], x[1][1])) \
         .write_text(output_file, write_mode=WriteMode.OVERWRITE)
 
     env.execute(local=True)

--- a/mandelbrot/mandelbrot_set.py
+++ b/mandelbrot/mandelbrot_set.py
@@ -3,7 +3,7 @@ import json
 import sys
 import numpy as np
 from flink.plan.Environment import get_environment
-from flink.plan.Constants import INT, STRING, FLOAT, WriteMode
+from flink.plan.Constants import FLOAT, WriteMode
 from flink.functions.GroupReduceFunction import GroupReduceFunction
 
 __author__ = 'willmcginnis/1oclockbuzz'
@@ -63,9 +63,9 @@ if __name__ == "__main__":
     data = env.read_csv(input_file, types=[FLOAT, FLOAT])
 
     data \
-        .map(lambda x: check_c(x), (FLOAT, FLOAT, FLOAT)) \
+        .map(lambda x: check_c(x)) \
         .filter(lambda x: True if x[0] != -999 else False) \
-        .map(lambda x: '%s + %sj, %s' % (x[0], x[1], x[2]), STRING) \
+        .map(lambda x: '%s + %sj, %s' % (x[0], x[1], x[2])) \
         .write_text(output_file, write_mode=WriteMode.OVERWRITE)
 
     # execute the plan locally.

--- a/mean_values/mean_values.py
+++ b/mean_values/mean_values.py
@@ -3,7 +3,7 @@ import random
 import sys
 
 from flink.plan.Environment import get_environment
-from flink.plan.Constants import INT, STRING, WriteMode, FLOAT
+from flink.plan.Constants import WriteMode, FLOAT
 from flink.functions.ReduceFunction import ReduceFunction
 
 __author__ = 'willmcginnis'
@@ -39,11 +39,11 @@ if __name__ == "__main__":
 
     # add a 1 in the 0 index for counting the number of samples, then reduce to get all sums and divide for means
     data \
-        .map(lambda x: (1, x[0], x[1]), (INT, FLOAT, FLOAT)) \
+        .map(lambda x: (1, x[0], x[1])) \
         .group_by(0) \
         .reduce(MeanReducer()) \
-        .map(lambda x: (x[1]/x[0], x[2]/x[0]), (FLOAT, FLOAT)) \
-        .map(lambda x: 'mean of col 0: %f\nmean of col 1: %f' % (x[0], x[1]), STRING) \
+        .map(lambda x: (x[1]/x[0], x[2]/x[0])) \
+        .map(lambda x: 'mean of col 0: %f\nmean of col 1: %f' % (x[0], x[1])) \
         .write_text(output_file, write_mode=WriteMode.OVERWRITE)
 
     env.execute(local=True)

--- a/runner.py
+++ b/runner.py
@@ -1,9 +1,8 @@
 import os
+import sys
 
 __author__ = 'willmcginnis'
 
-
-PYFLINK = 'pyflink3.sh'
 project_directory = str(os.path.dirname(os.path.abspath(__file__)))
 
 
@@ -53,6 +52,13 @@ def run_mandelbrot():
 
 
 if __name__ == '__main__':
+    if len(sys.argv) > 1 and \
+       type(sys.argv[1]) is str and \
+       os.path.exists(sys.argv[1]):
+        PYFLINK = sys.argv[1]
+    else:
+        PYFLINK = 'pyflink3.sh'
+
     print('RUNNING MANDELBROT SET EXAMPLE')
     run_mandelbrot()
 

--- a/trending_hashtags/trending_hashtags.py
+++ b/trending_hashtags/trending_hashtags.py
@@ -3,7 +3,7 @@ import random
 import sys
 
 from flink.plan.Environment import get_environment
-from flink.plan.Constants import INT, STRING, WriteMode
+from flink.plan.Constants import WriteMode
 from flink.functions.GroupReduceFunction import GroupReduceFunction
 
 __author__ = 'willmcginnis'
@@ -39,11 +39,11 @@ if __name__ == "__main__":
     data = env.read_text(input_file)
 
     data \
-        .flat_map(lambda x, c: [(1, word) for word in x.lower().split()], (INT, STRING)) \
+        .flat_map(lambda x, c: [(1, word) for word in x.lower().split()]) \
         .filter(lambda x: '#' in x[1]) \
         .group_by(1) \
-        .reduce_group(Adder(), (INT, STRING), combinable=True) \
-        .map(lambda y: (str(y[0]), y[1]), (STRING, STRING)) \
+        .reduce_group(Adder(), combinable=True) \
+        .map(lambda y: (str(y[0]), y[1])) \
         .write_csv(output_file, line_delimiter='\n', field_delimiter=',', write_mode=WriteMode.OVERWRITE)
 
     env.execute(local=True)

--- a/word_count/word_count.py
+++ b/word_count/word_count.py
@@ -1,7 +1,7 @@
 import sys
 
 from flink.plan.Environment import get_environment
-from flink.plan.Constants import INT, STRING, WriteMode
+from flink.plan.Constants import WriteMode
 from flink.functions.GroupReduceFunction import GroupReduceFunction
 
 
@@ -25,10 +25,10 @@ if __name__ == "__main__":
     # we first map each word into a (1, word) tuple, then flat map across that, and group by the key, and sum
     # aggregate on it to get (count, word) tuples, then pretty print that out to a file.
     data \
-        .flat_map(lambda x, c: [(1, word) for word in x.lower().split()], (INT, STRING)) \
+        .flat_map(lambda x, c: [(1, word) for word in x.lower().split()]) \
         .group_by(1) \
-        .reduce_group(Adder(), (INT, STRING), combinable=True) \
-        .map(lambda y: 'Count: %s Word: %s' % (y[0], y[1]), STRING) \
+        .reduce_group(Adder(), combinable=True) \
+        .map(lambda y: 'Count: %s Word: %s' % (y[0], y[1])) \
         .write_text(output_file, write_mode=WriteMode.OVERWRITE)
 
     # execute the plan locally.


### PR DESCRIPTION
type definition is not necessary anymore since apache/flink@ab84707 commit removes it.
Actually It'll raise `TypeError` like:

```
TypeError: flat_map() takes 2 positional arguments but 3 were given
```

If you try to define types. Also I've made a change in `runner.py` to make it able to get `pyflink*.py` from command line argument. 

Thanks
