### PR TITLE
fix argv index

### DIFF
--- a/word_count/word_count.py
+++ b/word_count/word_count.py
@@ -13,7 +13,7 @@ class Adder(GroupReduceFunction):
 
 if __name__ == "__main__":
     # get the base path out of the runtime params
-    base_path = sys.argv[1]
+    base_path = sys.argv[0]
 
     # we have to hard code in the path to the output because of gotcha detailed in readme
     output_file = 'file://' + base_path + '/word_count/out.txt'


### PR DESCRIPTION
I get the following on osx with `argv[1]`. `argv[0]` works.

> Traceback (most recent call last):
>   File "/var/folders/bj/cz3bh3zj29v5v3d0plcf2rvdf5lwdf/T//flink_plan406514535/plan.py", line 16, in <module>
>     base_path = sys.argv[1]
> IndexError: list index out of range