### PR TITLE
Pin Flink image and apache-flink/numpy versions for reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM flink:latest
+FROM flink:1.19.0-scala_2.12-java11
 
 # install python3 and pip3
 RUN apt-get update -y && \
 apt-get install -y python3 python3-pip python3-dev openjdk-11-jdk && rm -rf /var/lib/apt/lists/*
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
-# install PyFlink
-RUN pip3 install numpy apache-flink  
+# install PyFlink from the pinned requirements (single source of truth)
+COPY requirements.txt /tmp/requirements.txt
+RUN pip3 install -r /tmp/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-apache-flink
-numpy 
+apache-flink==1.19.0
+numpy==1.22.4


### PR DESCRIPTION
Closes #9

## What changed
Pins the Docker build to a single, internally-consistent version set so rebuilds are reproducible and PyFlink can't drift out of sync with the Flink cluster.

- **`Dockerfile`**: `FROM flink:latest` → `FROM flink:1.19.0-scala_2.12-java11` (now matches the README).
- **`requirements.txt`**: `apache-flink` → `apache-flink==1.19.0` (matches the image tag exactly) and `numpy` → `numpy==1.22.4`.
- **`Dockerfile`**: replaced the inline unpinned `pip3 install numpy apache-flink` with `COPY requirements.txt` + `pip3 install -r requirements.txt`, so the pins are the single source of truth (this also makes the README's existing "Copies requirements.txt / installs from it" description accurate).

### Why numpy==1.22.4
`apache-flink==1.19.0` pulls `apache-beam`, which constrains `numpy<1.23.0,>=1.14.3`, while PyFlink itself requires `numpy>=1.22.4`. The only version satisfying both is `1.22.4`. (An initial `numpy==1.26.4` was rejected by the resolver during verification.)

The README already names `flink:1.19.0-scala_2.12-java11`, so the Dockerfile base tag, the `apache-flink` pin, and the README now all agree.

## Verification
- `docker build --platform linux/amd64 .` — **succeeds**. pip resolves and installs the full pinned set (`apache-flink-1.19.0`, `numpy-1.22.4`, `pemja-0.4.1`, `apache-beam-2.48.0`, …) with no conflicts.
- Ran a sample job against the built image (local Flink cluster, repo mounted at `/opt/flink/usrlib`):
  - `mean_values/mean_values.py` → **runs to completion**, emits `199 rows in set` and `Mean Values Job Submitted`. This exercises the CSV filesystem connector and Table aggregation end-to-end on the pinned image.

## Notes (out of scope — not changed here)
- `word_count/word_count.py` fails at runtime with `TypeError: RowType can not accept object "..." in type <class 'str'>` — it passes a list of bare strings to `from_elements(...)` with a `ROW` schema (expects row tuples). This is a pre-existing bug in the example code, independent of version pinning, and is left for a separate issue.
- On `arm64` hosts (Apple Silicon), `pemja==0.4.1` has no prebuilt wheel and its source build looks for a JDK at the base image's `JAVA_HOME`; the build succeeds under `--platform linux/amd64` emulation. Addressing native arm64 builds is a separate concern from this pinning change.