### PR TITLE
Fix invalid docker compose flags in Makefile start-flink target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ setup: check_uv requirements.txt
 # Start Flink cluster using Docker Compose
 start-flink:
 	@echo "Starting Flink cluster via Docker Compose..."
-	@docker compose up -d --verbose --build --no-cache
+	@docker compose up -d --build
 	@echo "Flink cluster started. UI should be available at http://localhost:8081"
 
 # Stop Flink cluster


### PR DESCRIPTION
Closes #8

## Summary
The `start-flink` Makefile target ran:

```make
@docker compose up -d --verbose --build --no-cache
```

`--verbose` and `--no-cache` are not valid flags for `docker compose up` in Compose v2+ (`--no-cache` belongs to `docker compose build`). Compose aborts on the first unknown flag, so the headline `make start-flink` / `make run` workflow failed out of the box (matching commit 91aa2ed, "docker build not working yet").

## Change
Replaced the invocation with the standard, documented form already shown in the README:

```make
@docker compose up -d --build
```

`--build` still rebuilds the image on `up`; `--verbose` is dropped and `--no-cache` is omitted (a cache-busting rebuild, if ever needed, belongs on a separate `docker compose build --no-cache` step). Only this one recipe line changed.

## Verification
- Environment: Docker Compose v5.1.4.
- `make -n start-flink` now emits `docker compose up -d --build`.
- Confirmed the old command is rejected: `docker compose up -d --verbose --build --no-cache` → `unknown flag: --verbose`.
- Confirmed `--build` and `-d/--detach` are valid `docker compose up` flags via `docker compose up --help`; `--no-cache`/`--verbose` are not listed.
- README already documents `docker compose up -d --build`, so Makefile and docs are now consistent.

(A full cluster bring-up was not executed in this environment, but the flag-validity failure that blocked startup is resolved.)