### PR TITLE
Add end-to-end Flink CI smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    env:
+      COMPOSE_FILE: docker-compose.yml:/tmp/docker-compose.ci.yml
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/setup-compose-action@v2
+
+      - uses: crazy-max/ghaction-github-runtime@v3
+
+      - name: Configure Docker layer cache
+        run: |
+          cat > /tmp/docker-compose.ci.yml <<'EOF'
+          services:
+            jobmanager:
+              build:
+                cache_from:
+                  - type=gha,scope=flink-image
+                cache_to:
+                  - type=gha,mode=max,scope=flink-image
+            taskmanager:
+              build:
+                cache_from:
+                  - type=gha,scope=flink-image
+                cache_to:
+                  - type=gha,mode=max,scope=flink-image
+          EOF
+
+      - name: Build image and start Flink
+        run: make start-flink
+
+      - name: Wait for Flink
+        run: |
+          for _ in {1..60}; do
+            if curl --fail --silent http://localhost:8081/overview \
+              | jq --exit-status '.taskmanagers >= 1' > /dev/null; then
+              exit 0
+            fi
+            sleep 5
+          done
+          docker compose ps
+          docker compose logs
+          exit 1
+
+      # Add word_count and trending_hashtags after their known runtime failures are fixed.
+      - name: Run mean values end to end
+        shell: bash
+        run: |
+          set -o pipefail
+          make submit_mean_values | tee /tmp/mean-values.log
+          grep -E '^\|[[:space:]]*\+I[[:space:]]*\|[[:space:]]*0\.[0-9]+[[:space:]]*\|[[:space:]]*0\.[0-9]+[[:space:]]*\|$' /tmp/mean-values.log
+
+      - name: Stop Flink
+        if: always()
+        run: make stop-flink


### PR DESCRIPTION
Closes #15

## Summary

- add push and pull-request CI that builds and starts the real Compose cluster through `make start-flink`
- wait for the JobManager to report a registered TaskManager before submission
- run `make submit_mean_values` and require a printed result row containing two decimal mean values
- cache BuildKit layers with the GitHub Actions cache backend and always run `make stop-flink`
- leave the known-broken word-count and trending-hashtags targets explicitly deferred

## Verification

- `actionlint .github/workflows/ci.yml` — passed
- `docker compose config` with the CI cache override — passed
- `DOCKER_DEFAULT_PLATFORM=linux/amd64 make start-flink` — built the pinned image and started both services
- waited on `/overview` for a registered TaskManager, then ran `make submit_mean_values` with the workflow assertion — passed; output contained 199 changelog rows and a populated two-mean `+I` row
- mutation proof: temporarily changed the filesystem source path to `in.txt.missing`; `make submit_mean_values` failed with `FileNotFoundException`, proving the smoke gate catches a broken source; restored the path afterward
- `make stop-flink` — passed
- `git diff --check` and final status review — passed; the generated `mean_values/in.txt` and mutation were restored, leaving no stray application diff